### PR TITLE
feat: add favicon to the playground app

### DIFF
--- a/packages/playground/index.html
+++ b/packages/playground/index.html
@@ -23,6 +23,7 @@
     <meta name="twitter:image" content="https://opengraph.b-cdn.net/production/images/62488971-bd71-48ba-ad5c-bebc490cce57.png?token=t2C8imb5PNGz_PlWYzd9bMJ5hGzqv_VLyjCAIw90wmw&height=630&width=1200&expires=33282143125">
 
     <!-- Meta Tags Generated via https://www.opengraph.xyz -->
+    <link rel="icon" type="image/x-icon" href="/noirlingsapp.ico" />
   </head>
   <body>
     <div id="root"></div>

--- a/summary.md
+++ b/summary.md
@@ -23,3 +23,8 @@ You can now reinstall dependencies and redeploy the app on Vercel.
 - These changes ensure that sharing the site link will display the custom image and text on social platforms and messaging apps.
 
 - Moved the X (Twitter) logo button to appear next to the Noirlings logo on the left side of the toolbar for better branding and visibility.
+
+## [Favicon Added]
+
+- Added `<link rel="icon" type="image/x-icon" href="/noirlingsapp.ico" />` to `packages/playground/index.html` <head> section.
+- This sets the favicon for the playground app to the provided noirlingsapp.ico file located in packages/playground/public/.


### PR DESCRIPTION
- Added a favicon link to `packages/playground/index.html`, setting the favicon for the playground app to `noirlingsapp.ico`.
- Updated `summary.md` to document this addition and its impact on the user interface.