### PR TITLE
feat: enhance share templates in NoirEditor for improved user engagement

### DIFF
--- a/packages/playground/src/components/editor/NoirEditor.tsx
+++ b/packages/playground/src/components/editor/NoirEditor.tsx
@@ -67,15 +67,15 @@ function NoirEditor(props: PlaygroundProps) {
 
   // Share text templates
   const shareTemplates = [
-    "Just smashed {finished}/{total} Noirlings exercises, bullish af ⚡️\n\nLevel up your Noir game here: https://noirlings.app \n\n@NoirLang",
-    "{finished}/{total} Noirlings done, privacy arc started 🚀\n\nYour turn anon: https://noirlings.app \n\n@NoirLang",
-    "Grinding Noirlings {finished}/{total}, gonna make it fr 🔥\n\nJoin the quest: https://noirlings.app \n\n@NoirLang",
-    "{finished}/{total} Noirlings crushed! Ready to speedrun zk skills?\n\nHop in: https://noirlings.app \n\n@NoirLang",
-    "{finished} outta {total} Noirlings exercises checked ✅\nNoir skills loading… \n\nGet your zk reps in here: https://noirlings.app \n\n@NoirLang",
-    "I'm {finished}/{total} into Noirlings already, don't sleep anon 😴\n\nStart before your frens: https://noirlings.app \n\n@NoirLang",
-    "Achievement unlocked: {finished}/{total} Noirlings 🕹️\n\nLevel up: https://noirlings.app \n\n@NoirLang",
-    "{finished}/{total} done on Noirlings - can you beat me anon? 🎯\n\nShow your skillz: https://noirlings.app \n\n@NoirLang",
-    "Long on Noir, entry at {finished}/{total} Noirlings exercises 📈\n\nDYOR here: https://noirlings.app \n\n@NoirLang",
+    "Just smashed {finished}/{total} Noirlings exercises, bullish af ⚡️\n\nLevel up your Noir game here: https://noirlings.app \n\n@NoirLang @andeebtceth",
+    "{finished}/{total} Noirlings done, privacy arc started 🚀\n\nYour turn anon: https://noirlings.app \n\n@NoirLang @andeebtceth",
+    "Grinding Noirlings {finished}/{total}, gonna make it fr 🔥\n\nJoin the quest: https://noirlings.app \n\n@NoirLang @andeebtceth",
+    "{finished}/{total} Noirlings crushed! Ready to speedrun zk skills?\n\nHop in: https://noirlings.app \n\n@NoirLang @andeebtceth",
+    "{finished} outta {total} Noirlings exercises checked ✅\nNoir skills loading… \n\nGet your zk reps in here: https://noirlings.app \n\n@NoirLang @andeebtceth",
+    "I'm {finished}/{total} into Noirlings already, don't sleep anon 😴\n\nStart before your frens: https://noirlings.app \n\n@NoirLang @andeebtceth",
+    "Achievement unlocked: {finished}/{total} Noirlings 🕹️\n\nLevel up: https://noirlings.app \n\n@NoirLang @andeebtceth",
+    "{finished}/{total} done on Noirlings - can you beat me anon? 🎯\n\nShow your skillz: https://noirlings.app \n\n@NoirLang @andeebtceth",
+    "Long on Noir, entry at {finished}/{total} Noirlings exercises 📈\n\nDYOR here: https://noirlings.app \n\n@NoirLang @andeebtceth",
   ];
 
   // Enhanced mouse event handlers for draggable separator


### PR DESCRIPTION
- Updated share templates in `NoirEditor.tsx` to include the new branding handle `@andeebtceth`, enhancing visibility and engagement on social media.